### PR TITLE
Add Brave LinkedIn scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+raw_links.csv
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# scraper-profession
-Scraper for Professions
+# Scraper Profession
+
+This repository contains a simple scraper that collects LinkedIn profile URLs for various professions related to **Santa Clara University** using the Brave Search API.
+
+## Requirements
+
+- Python 3.12+
+- [`requests`](https://pypi.org/project/requests/) (see `requirements.txt`)
+- A Brave Search API key stored in the environment variable `BRAVE_API_KEY`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the scraper:
+
+```bash
+python brave_linkedin_scraper.py
+```
+
+The script will generate a `raw_links.csv` file with columns:
+
+- `name` – the person's name as extracted from the search result
+- `linkedin_url` – direct link to the LinkedIn profile
+- `search_keyword` – the keyword used for the search
+- `profession` – the profession category
+
+The scraper cycles through a predefined set of professions and keyword variants, aiming to collect about 40 unique profiles per profession (approximately 600 in total).

--- a/brave_linkedin_scraper.py
+++ b/brave_linkedin_scraper.py
@@ -1,0 +1,213 @@
+import os
+import csv
+import time
+from typing import Dict, List, Set
+
+import requests
+
+# Mapping of profession to keyword variants
+PROFESSIONS: Dict[str, List[str]] = {
+    "Software Engineer": [
+        "Software Engineer",
+        "Backend Developer",
+        "Full Stack Engineer",
+        "Platform Engineer",
+        "SWE",
+    ],
+    "Data Scientist": [
+        "Data Scientist",
+        "Machine Learning",
+        "AI Research",
+        "ML Engineer",
+    ],
+    "Product Manager": [
+        "Product Manager",
+        "Product Lead",
+        "Product Owner",
+    ],
+    "UX/UI Designer": [
+        "UX Designer",
+        "UI/UX",
+        "Product Design",
+        "Interaction Designer",
+    ],
+    "Mechanical Engineer": [
+        "Mechanical Engineer",
+        "Product Development",
+        "Manufacturing Engineer",
+    ],
+    "Electrical Engineer": [
+        "Electrical Engineer",
+        "Embedded Systems",
+        "Hardware Engineer",
+    ],
+    "Investment Analyst": [
+        "Investment Analyst",
+        "Equity Research",
+        "Portfolio Analyst",
+        "Buy-side Analyst",
+    ],
+    "Consultant": [
+        "Consultant",
+        "Strategy Consulting",
+        "Management Consultant",
+        "Business Analyst",
+    ],
+    "Lawyer": [
+        "Attorney",
+        "Corporate Law",
+        "Legal Counsel",
+        "Litigation Associate",
+    ],
+    "Physician / Med": [
+        "Physician",
+        "Doctor",
+        "Healthcare",
+        "Resident MD",
+        "Medical Professional",
+    ],
+    "Research Scientist": [
+        "Research Scientist",
+        "PhD Candidate",
+        "Lab Assistant",
+        "Postdoctoral Researcher",
+    ],
+    "Educator": [
+        "Teacher",
+        "Professor",
+        "Lecturer",
+        "Adjunct Instructor",
+    ],
+    "Journalist": [
+        "Journalist",
+        "News Reporter",
+        "Editor",
+        "Columnist",
+    ],
+    "Marketing / PR": [
+        "Marketing",
+        "Brand Manager",
+        "Public Relations",
+        "Content Marketing",
+    ],
+    "Designer / Creator": [
+        "Graphic Designer",
+        "Illustrator",
+        "Creative Director",
+        "Visual Designer",
+    ],
+}
+
+API_URL = "https://api.search.brave.com/res/v1/web/search"
+QUERY_TEMPLATE = 'site:linkedin.com/in "Santa Clara University" "{}"'
+RESULTS_PER_PAGE = 20  # Brave API supports up to 20 results per page
+TARGET_RESULTS_PER_PROFESSION = 40
+
+
+def brave_search(query: str, offset: int, api_key: str) -> Dict:
+    """Perform a single Brave Search API request."""
+    headers = {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "X-Subscription-Token": api_key,
+    }
+    params = {
+        "q": query,
+        "source": "api",
+        "count": RESULTS_PER_PAGE,
+        "offset": offset,
+    }
+    response = requests.get(API_URL, headers=headers, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def parse_result(item: Dict) -> Dict:
+    """Extract relevant information from a Brave search result item."""
+    url = item.get("url", "")
+    if "/in/" not in url:
+        return {}
+
+    # Attempt to extract a human readable name from the title or description
+    title = item.get("title", "")
+    snippet = item.get("description", "")
+    name = title.split("-")[0].strip() if title else snippet.split("-")[0].strip()
+
+    return {"name": name, "linkedin_url": url}
+
+
+def collect_profiles(api_key: str) -> List[Dict[str, str]]:
+    profiles: List[Dict[str, str]] = []
+    seen_urls: Set[str] = set()
+    seen_names: Set[str] = set()
+
+    for profession, keywords in PROFESSIONS.items():
+        count_for_profession = 0
+        keyword_index = 0
+
+        # Continue until we have enough profiles for this profession
+        while count_for_profession < TARGET_RESULTS_PER_PROFESSION:
+            keyword = keywords[keyword_index % len(keywords)]
+            keyword_index += 1
+            query = QUERY_TEMPLATE.format(keyword)
+            offset = 0
+
+            while count_for_profession < TARGET_RESULTS_PER_PROFESSION:
+                data = brave_search(query, offset=offset, api_key=api_key)
+                results = data.get("web", {}).get("results", [])
+                if not results:
+                    break
+
+                for item in results:
+                    parsed = parse_result(item)
+                    if not parsed:
+                        continue
+
+                    url = parsed["linkedin_url"]
+                    name = parsed["name"]
+
+                    if url in seen_urls or name.lower() in seen_names:
+                        continue
+
+                    profiles.append(
+                        {
+                            "name": name,
+                            "linkedin_url": url,
+                            "search_keyword": keyword,
+                            "profession": profession,
+                        }
+                    )
+
+                    seen_urls.add(url)
+                    seen_names.add(name.lower())
+                    count_for_profession += 1
+
+                    if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                        break
+
+                offset += RESULTS_PER_PAGE
+                time.sleep(1)  # avoid hitting rate limits
+
+    return profiles
+
+
+def save_csv(records: List[Dict[str, str]], filename: str) -> None:
+    with open(filename, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["name", "linkedin_url", "search_keyword", "profession"]
+        )
+        writer.writeheader()
+        writer.writerows(records)
+
+
+def main() -> None:
+    api_key = os.getenv("BRAVE_API_KEY")
+    if not api_key:
+        raise EnvironmentError("BRAVE_API_KEY environment variable is required")
+
+    profiles = collect_profiles(api_key)
+    save_csv(profiles, "raw_links.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- implement `brave_linkedin_scraper.py` to gather LinkedIn profile links via Brave Search API
- add `requirements.txt` and ignore output files
- update README with instructions for installing dependencies and running the scraper

## Testing
- `python3 -m py_compile brave_linkedin_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6859d37bac6c83238437c1e68ea5a0f4