### PR TITLE
feat: Implement two-phase LinkedIn profile scraping

### DIFF
--- a/google_linkedin_scraper.py
+++ b/google_linkedin_scraper.py
@@ -103,11 +103,30 @@ PROFESSIONS: Dict[str, List[str]] = {
     ],
 }
 
+PROFESSION_TO_COMPANIES: Dict[str, List[str]] = {
+    "Software Engineer": ["Google", "Microsoft", "Amazon", "Apple", "Meta", "Netflix", "Tesla", "NVIDIA", "Intel", "Oracle"],
+    "Data Scientist": ["Google DeepMind", "OpenAI", "Netflix", "Tesla", "Airbnb", "Stripe"],
+    "Product Manager": ["Google", "Amazon", "Microsoft", "Salesforce", "Atlassian", "Shopify"],
+    "UX/UI Designer": ["IDEO", "Apple", "Airbnb", "Figma", "Adobe", "Google"],
+    "Mechanical Engineer": ["SpaceX", "Tesla", "Boeing", "GE Aerospace", "Lockheed Martin", "Boston Dynamics"],
+    "Electrical Engineer": ["Intel", "NVIDIA", "Qualcomm", "Texas Instruments", "AMD", "Apple"],
+    "Investment Analyst": ["Goldman Sachs", "Morgan Stanley", "BlackRock", "Fidelity Investments", "Bridgewater Associates", "KKR"],
+    "Consultant": ["McKinsey & Company", "Boston Consulting Group", "Bain & Company", "Deloitte Consulting", "Accenture Strategy", "Oliver Wyman"],
+    "Lawyer": ["Skadden", "Cravath", "Sullivan & Cromwell", "Kirkland & Ellis", "Latham & Watkins", "Wachtell"],
+    "Physician / Med": ["Mayo Clinic", "Cleveland Clinic", "Johns Hopkins Hospital", "Mass General", "Stanford Health Care", "UCLA Medical Center"], # Changed key to match PROFESSIONS
+    "Research Scientist": ["NASA JPL", "CERN", "Broad Institute", "IBM Research", "Max Planck Society", "Lawrence Berkeley Lab"],
+    "Educator": ["MIT", "Stanford", "Harvard", "Oxford", "Cambridge", "UC Berkeley"],
+    "Journalist": ["New York Times", "Washington Post", "WSJ", "BBC", "Reuters", "Guardian"],
+    "Marketing / PR": ["Procter & Gamble", "Nike", "Unilever", "Coca-Cola", "Ogilvy", "Edelman"],
+    "Designer / Creator": ["Pentagram", "IDEO", "Pixar", "Apple Design Studio", "Walt Disney Imagineering", "Nike Design"]
+}
+
 API_URL = "https://www.googleapis.com/customsearch/v1"
 QUERY_TEMPLATE = 'site:linkedin.com/in "Santa Clara University" {}'
 RESULTS_PER_PAGE = 10  # Google Custom Search returns up to 10 results per page
 MAX_OFFSET = 9
 TARGET_RESULTS_PER_PROFESSION = 40
+TARGET_RESULTS_PER_COMPANY = 10 # Optional: Max results per company per profession
 
 
 def google_search(query: str, offset: int, api_key: str, cx: str) -> Dict:
@@ -180,6 +199,7 @@ def collect_profiles(api_key: str, cx: str) -> tuple[list[dict[str, str]], str]:
 
     profiles: List[Dict[str, str]] = []
     seen_urls: Set[str] = set()
+    # seen_names: Set[str] = set() # Add if name uniqueness is strictly required
 
     # Create/clear the CSV file at the start
     csv_filename = f"raw_links_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
@@ -189,54 +209,149 @@ def collect_profiles(api_key: str, cx: str) -> tuple[list[dict[str, str]], str]:
     for profession, keywords in PROFESSIONS.items():
         print(f"\nProcessing profession: {profession}")
         count_for_profession = 0
-        keyword_index = 0
 
-        # Continue until we have enough profiles for this profession
-        while count_for_profession < TARGET_RESULTS_PER_PROFESSION:
-            keyword = keywords[keyword_index % len(keywords)]
-            keyword_index += 1
-            query = QUERY_TEMPLATE.format(keyword)
-            offset = 0
+        # Phase 1: Generic Keyword Search
+        print(f"--- Phase 1: Generic Keyword Search for {profession} ---")
+        keyword_index_phase1 = 0
+        # Continue until we have enough profiles for this profession or run out of keyword/offset combinations
+        # Need to ensure keyword_index_phase1 doesn't go into an infinite loop if MAX_OFFSET is always hit before TARGET_RESULTS
+        # A better way might be to iterate offsets for each keyword explicitly.
 
-            # Limit offset to MAX_OFFSET (9)
-            while count_for_profession < TARGET_RESULTS_PER_PROFESSION and offset <= MAX_OFFSET:
-                data = google_search(query, offset=offset, api_key=api_key, cx=cx)
-                results = data.get("items", [])
-                if not results:
-                    break
+        # Iterate through each keyword once for Phase 1
+        for keyword_p1 in keywords:
+            if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                break # Already have enough for this profession
 
-                for item in results:
-                    parsed = parse_result(item)
-                    if not parsed:
+            print(f"Searching with keyword: {keyword_p1}")
+            query_p1 = QUERY_TEMPLATE.format(f'"{keyword_p1}"') # Ensure keyword is quoted if it contains spaces
+            offset_p1 = 0
+            while count_for_profession < TARGET_RESULTS_PER_PROFESSION and offset_p1 <= MAX_OFFSET:
+                data_p1 = google_search(query_p1, offset=offset_p1, api_key=api_key, cx=cx)
+                results_p1 = data_p1.get("items", [])
+                if not results_p1:
+                    print(f"No more results for keyword '{keyword_p1}' at offset {offset_p1}.")
+                    break # No more results for this keyword at this offset
+
+                for item_p1 in results_p1:
+                    parsed_p1 = parse_result(item_p1)
+                    if not parsed_p1:
                         continue
 
-                    url = parsed["linkedin_url"]
-                    name = parsed["name"]
+                    url_p1 = parsed_p1["linkedin_url"]
+                    name_p1 = parsed_p1["name"]
 
-                    if url in seen_urls:
+                    if url_p1 in seen_urls: # Global check
                         continue
+                    # if name_p1 in seen_names: # Optional: if name uniqueness is required
+                    #     continue
 
-                    profile_record = {
-                        "name": name,
-                        "linkedin_url": url,
-                        "search_keyword": keyword,
+                    profile_record_p1 = {
+                        "name": name_p1,
+                        "linkedin_url": url_p1,
+                        "search_keyword": keyword_p1, # Store the specific keyword
                         "profession": profession,
                     }
                     
-                    profiles.append(profile_record)
-                    
-                    # Immediately append to CSV
-                    append_to_csv(profile_record, csv_filename)
-                    print(f"Added: {name} ({profession})")
+                    profiles.append(profile_record_p1)
+                    append_to_csv(profile_record_p1, csv_filename)
+                    print(f"Added (Phase 1): {name_p1} ({profession}) - Keyword: {keyword_p1}")
 
-                    seen_urls.add(url)
+                    seen_urls.add(url_p1)
+                    # seen_names.add(name_p1)
                     count_for_profession += 1
 
                     if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
                         break
 
-                offset += 1  # Changed from RESULTS_PER_PAGE to 1
-                time.sleep(2)  # Increased from 1 to 2 seconds to respect rate limit
+                if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                    break
+                offset_p1 += 1
+                time.sleep(2)
+            if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                print(f"Target for {profession} reached during Phase 1.")
+                break # Break from keyword loop for Phase 1
+
+        # Phase 2: Targeted Company Search
+        if count_for_profession < TARGET_RESULTS_PER_PROFESSION:
+            print(f"--- Phase 2: Targeted Company Search for {profession} ---")
+            target_companies = PROFESSION_TO_COMPANIES.get(profession, [])
+            if not target_companies:
+                print(f"No target companies defined for {profession}. Skipping Phase 2.")
+            else:
+                results_by_company_for_profession: Dict[str, int] = {comp: 0 for comp in target_companies}
+
+                for company in target_companies:
+                    if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                        break # Overall target for profession met
+
+                    print(f"Targeting company: {company} for {profession}")
+
+                    for keyword_p2 in keywords: # Iterate through the same keywords
+                        if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                            break
+                        if results_by_company_for_profession.get(company, 0) >= TARGET_RESULTS_PER_COMPANY:
+                            print(f"Target for company '{company}' in '{profession}' reached.")
+                            break # Target for this specific company met
+
+                        # Ensure company name is quoted if it contains spaces, keyword too
+                        query_p2 = QUERY_TEMPLATE.format(f'"{keyword_p2}" "{company}"')
+                        offset_p2 = 0
+
+                        while count_for_profession < TARGET_RESULTS_PER_PROFESSION and \
+                              results_by_company_for_profession.get(company, 0) < TARGET_RESULTS_PER_COMPANY and \
+                              offset_p2 <= MAX_OFFSET:
+
+                            data_p2 = google_search(query_p2, offset=offset_p2, api_key=api_key, cx=cx)
+                            results_p2 = data_p2.get("items", [])
+                            if not results_p2:
+                                print(f"No more results for keyword '{keyword_p2}', company '{company}' at offset {offset_p2}.")
+                                break
+
+                            for item_p2 in results_p2:
+                                parsed_p2 = parse_result(item_p2)
+                                if not parsed_p2:
+                                    continue
+
+                                url_p2 = parsed_p2["linkedin_url"]
+                                name_p2 = parsed_p2["name"]
+
+                                if url_p2 in seen_urls: # Global check
+                                    continue
+                                # if name_p2 in seen_names:
+                                #    continue
+
+                                profile_record_p2 = {
+                                    "name": name_p2,
+                                    "linkedin_url": url_p2,
+                                    "search_keyword": f"{keyword_p2} @ {company}", # Indicate company search
+                                    "profession": profession,
+                                }
+
+                                profiles.append(profile_record_p2)
+                                append_to_csv(profile_record_p2, csv_filename)
+                                print(f"Added (Phase 2): {name_p2} ({profession}) - Keyword: {keyword_p2}, Company: {company}")
+
+                                seen_urls.add(url_p2)
+                                # seen_names.add(name_p2)
+                                count_for_profession += 1
+                                results_by_company_for_profession[company] = results_by_company_for_profession.get(company, 0) + 1
+
+                                if count_for_profession >= TARGET_RESULTS_PER_PROFESSION or \
+                                   results_by_company_for_profession.get(company, 0) >= TARGET_RESULTS_PER_COMPANY:
+                                    break
+
+                            if count_for_profession >= TARGET_RESULTS_PER_PROFESSION or \
+                               results_by_company_for_profession.get(company, 0) >= TARGET_RESULTS_PER_COMPANY:
+                                break
+                            offset_p2 += 1
+                            time.sleep(2)
+
+                        if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                            break # Break from keyword loop for Phase 2
+
+                    if count_for_profession >= TARGET_RESULTS_PER_PROFESSION:
+                        print(f"Target for {profession} reached during Phase 2 company searches.")
+                        break # Break from company loop for Phase 2
 
     print(f"\nCompleted! Total profiles collected: {len(profiles)}")
     return profiles, csv_filename


### PR DESCRIPTION
Implements a two-phase approach for scraping LinkedIn profiles from Google Search:

Phase 1: Generic Keyword Search
- Searches for profiles using profession-specific keywords.
- Query: site:linkedin.com/in "Santa Clara University" "{keyword}"

Phase 2: Targeted Company Search
- If more profiles are needed for a profession after Phase 1, this phase initiates searches targeted at prestigious companies for that profession.
- Query: site:linkedin.com/in "Santa Clara University" "{keyword}" "{company}"
- Adds a limit of TARGET_RESULTS_PER_COMPANY (e.g., 10) for profiles from any single company within a profession to improve diversity of results.

Both phases respect the overall TARGET_RESULTS_PER_PROFESSION limit. Uniqueness of profiles is maintained using their LinkedIn URLs. The 'search_keyword' column in the output CSV now indicates if a result came from a company-targeted search (e.g., "Software Engineer @ Google").